### PR TITLE
Fix: Prevent empty string in Image src attribute

### DIFF
--- a/src/components/BlogPostCard.js
+++ b/src/components/BlogPostCard.js
@@ -7,12 +7,16 @@ export default function BlogPostCard({ post }) {
     // El enlace ahora se construye con el slug del post
     <Link href={`/blog/${post.slug}`} className="block bg-white rounded-lg shadow-md overflow-hidden hover:shadow-xl transition-shadow duration-300">
       <div className="relative w-full h-48">
-        <Image
-          src={post.imageUrl}
-          alt={`Imagen para ${post.title}`}
-          layout="fill"
-          objectFit="cover"
-        />
+        {post.imageUrl ? (
+          <Image
+            src={post.imageUrl}
+            alt={`Imagen para ${post.title}`}
+            layout="fill"
+            objectFit="cover"
+          />
+        ) : (
+          <div className="w-full h-full bg-gray-200"></div> // Placeholder
+        )}
       </div>
       <div className="p-6">
         <h3 className="text-xl font-bold text-gray-800 mb-2">{post.title}</h3>


### PR DESCRIPTION
This commit fixes a console error in the BlogPostCard component.

The error was caused by passing an empty string to the `src` attribute of the Next.js Image component when a blog post did not have an associated image URL.

The fix introduces a conditional rendering check. If `post.imageUrl` is truthy, the Image component is rendered. Otherwise, a placeholder div with a gray background is rendered. This ensures that the Image component only receives valid URLs, resolving the error and improving the component's robustness.