### PR TITLE
feat: Add professional card to blog posts

### DIFF
--- a/src/app/blog/[slug]/page.js
+++ b/src/app/blog/[slug]/page.js
@@ -2,6 +2,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { PrismaClient } from '@prisma/client';
+import ProfessionalCard from '../../../components/ProfessionalCard';
 
 const prisma = new PrismaClient();
 
@@ -79,6 +80,8 @@ export default async function PostDetailPage({ params }) {
           <p>{post.content}</p>
         </div>
 
+        {/* Añadir el ProfessionalCard al final del post */}
+        {post.author && <ProfessionalCard professional={post.author} />}
       </div>
     </div>
   );

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -2,6 +2,7 @@
 import './globals.css'; // <-- ESTA LÍNEA ES LA MÁS IMPORTANTE
 import Header from '@/components/Header';
 import Footer from '@/components/Footer';
+import SessionProviderWrapper from '@/components/SessionProviderWrapper';
 
 export const metadata = {
   title: 'Salud Mental Costa Rica',
@@ -12,11 +13,13 @@ export default function RootLayout({ children }) {
   return (
     <html lang="es">
       <body className="flex flex-col min-h-screen bg-brand-background text-brand-dark">
-        <Header />
-        <main className="flex-grow">
-          {children}
-        </main>
-        <Footer />
+        <SessionProviderWrapper>
+          <Header />
+          <main className="flex-grow">
+            {children}
+          </main>
+          <Footer />
+        </SessionProviderWrapper>
       </body>
     </html>
   )

--- a/src/components/ProfessionalCard.js
+++ b/src/components/ProfessionalCard.js
@@ -1,0 +1,31 @@
+'use client';
+import React from 'react';
+import Link from 'next/link';
+import { useSession } from 'next-auth/react';
+
+const ProfessionalCard = ({ professional }) => {
+  const { data: session } = useSession();
+  const isUserLoggedIn = !!session;
+
+  return (
+    <div className="p-6 mt-12 bg-brand-background rounded-lg shadow-lg text-center">
+      <h3 className="text-2xl font-bold text-brand-primary mb-2">Sobre el autor</h3>
+      <p className="text-xl text-brand-text">{professional.name}</p>
+      <p className="text-md text-gray-500 mb-6">{professional.specialty}</p>
+
+      <div className="mt-4">
+        {isUserLoggedIn ? (
+          <Link href={`/perfil/${professional.id}/agendar`} className="px-6 py-3 text-white bg-brand-primary rounded-full hover:bg-brand-secondary transition-colors duration-300 shadow-md">
+            Agendar una cita
+          </Link>
+        ) : (
+          <Link href="/login" className="px-6 py-3 text-white bg-brand-primary rounded-full hover:bg-brand-secondary transition-colors duration-300 shadow-md">
+            Agendar una cita
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ProfessionalCard;

--- a/src/components/SessionProviderWrapper.js
+++ b/src/components/SessionProviderWrapper.js
@@ -1,0 +1,10 @@
+'use client';
+import { SessionProvider } from 'next-auth/react';
+
+export default function SessionProviderWrapper({ children }) {
+  return (
+    <SessionProvider>
+      {children}
+    </SessionProvider>
+  );
+}


### PR DESCRIPTION
This commit introduces a new component, `ProfessionalCard`, which is displayed at the end of each blog post.

The `ProfessionalCard` component displays information about the author of the post, including their name and specialty. It also includes a button to "Book an appointment".

The "Book an appointment" button will redirect to the login page if the user is not authenticated. If the user is authenticated, it will redirect to the professional's profile page to schedule an appointment.

Changes include:
- Creating the `ProfessionalCard` component.
- Modifying the blog post page to display the `ProfessionalCard`.
- Adding a `SessionProviderWrapper` to make the session available to all components.
- Updating the root layout to use the `SessionProviderWrapper`.